### PR TITLE
fix: resource-async clears error during retry

### DIFF
--- a/libs/ngx-lift/src/lib/signals/resource-async.spec.ts
+++ b/libs/ngx-lift/src/lib/signals/resource-async.spec.ts
@@ -1,6 +1,7 @@
 import {signal} from '@angular/core';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {delay, Observable, of, throwError} from 'rxjs';
+import {delay, Observable, of, throwError, timer} from 'rxjs';
+import {ignoreElements} from 'rxjs/operators';
 
 import {resourceAsync} from './resource-async';
 
@@ -13,7 +14,7 @@ interface User {
   name: string;
 }
 
-describe(resourceAsync.name, () => {
+describe('resourceAsync', () => {
   describe('basic functionality', () => {
     it('should auto-load data on init', fakeAsync(() => {
       TestBed.runInInjectionContext(() => {
@@ -636,7 +637,14 @@ describe(resourceAsync.name, () => {
 
     it('should handle empty observable (complete without value)', fakeAsync(() => {
       TestBed.runInInjectionContext(() => {
-        const resource = resourceAsync(() => of().pipe(delay(100)));
+        const resource = resourceAsync(
+          () =>
+            new Observable((observer) => {
+              setTimeout(() => {
+                observer.complete();
+              }, 100);
+            }),
+        );
 
         TestBed.tick();
         expect(resource.status()).toBe('loading');

--- a/libs/ngx-lift/src/lib/signals/resource-async.spec.ts
+++ b/libs/ngx-lift/src/lib/signals/resource-async.spec.ts
@@ -633,6 +633,43 @@ describe(resourceAsync.name, () => {
         expect(resource.error()).toBeNull();
       });
     }));
+
+    it('should handle empty observable (complete without value)', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const resource = resourceAsync(() => of().pipe(delay(100)));
+
+        TestBed.tick();
+        expect(resource.status()).toBe('loading');
+
+        tick(100);
+
+        expect(resource.status()).toBe('resolved');
+        expect(resource.value()).toBeUndefined();
+        expect(resource.error()).toBeNull();
+      });
+    }));
+  });
+
+  describe('error clearing', () => {
+    it('should clear error state immediately when reloading', fakeAsync(() => {
+      TestBed.runInInjectionContext(() => {
+        const error = new Error('Fail');
+        const resource = resourceAsync(() => promiseError(error, 100));
+
+        TestBed.tick();
+        tick(100);
+        expect(resource.status()).toBe('error');
+        expect(resource.error()).toBe(error);
+
+        // Reload
+        resource.reload();
+        TestBed.tick();
+
+        // Error should be cleared immediately
+        expect(resource.status()).toBe('loading');
+        expect(resource.error()).toBeNull();
+      });
+    }));
   });
 
   describe('type safety', () => {


### PR DESCRIPTION
## Description
Fixes an issue where `resourceAsync` would hang in a loading state if the source observable completed without emitting any values (e.g., `EMPTY`). Also ensures that previous error states are cleared immediately when a reload is triggered.

## Summary of Changes
- **Fix**: Add completion handler to subscription to properly resolve resources when source observable completes without value.
- **Fix**: Clear `errorSignal` when starting a new request (reloading).
- **Docs**: Update JSDoc for `value` signal.
- **Test**: Add test cases for empty observable handling and error clearing.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement
- [x] 🧪 Test update/addition
- [ ] 🔧 Configuration change
- [ ] 🎨 Style/UI update
- [ ] 🔒 Security fix

## Affected Projects
- [x] `ngx-lift`
- [ ] `clr-lift`
- [ ] `demo`
- [ ] Documentation
- [ ] CI/CD

## Breaking Changes
None.

## Testing
- [x] Added unit tests covering empty observable scenario.
- [x] Added unit tests covering error clearing on reload.
- [ ] Verified manually in demo app.

## Code Quality Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes